### PR TITLE
Add interactive menu for roster CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,102 @@
-# hr-mvp
-HR 관련 바이브코딩 테스트
+# HR MVP
+
+간단한 CSV 인사 명부를 기반으로 기본적인 통계와 검색 기능을 제공하는
+바이브코딩형 MVP입니다. 개발지식이 없어도 Python 하나만 설치되어 있다면
+터미널에서 바로 실행해볼 수 있도록 구성했습니다.
+
+## 준비물
+
+- Python 3.10 이상 (macOS, Windows, Linux 모두 가능)
+- 터미널(명령 프롬프트)에서 `python` 명령을 실행할 수 있어야 합니다.
+
+추가적인 라이브러리는 필요하지 않습니다. 저장소를 다운로드한 뒤 바로
+실행하면 됩니다.
+
+## 실행 방법
+
+1. 터미널을 열고 이 저장소 폴더로 이동합니다.
+   ```bash
+   cd hr-mvp
+   ```
+2. 가장 쉬운 방법은 인터랙티브 메뉴를 여는 것입니다.
+   ```bash
+   python -m hr_mvp.cli
+   ```
+   번호를 선택하면 즉시 해당 기능이 실행됩니다. 언제든지 `Q`를 눌러 종료할 수 있습니다.
+3. 특정 기능만 바로 실행하고 싶다면 다음과 같이 명령어를 사용할 수 있습니다.
+
+   ### 1) 전체 요약 확인
+   ```bash
+   python -m hr_mvp.cli summary
+   ```
+   - 전체/재직 인원 수
+   - 재직자의 평균 근속기간
+   - 팀별 재직 인원, 재직구분별 인원 분포
+
+   ### 2) 인원 목록 출력
+   ```bash
+   python -m hr_mvp.cli list
+   ```
+   `--active-only` 옵션을 추가하면 재직자만 표시합니다.
+
+   ### 3) 이름·팀·직책으로 검색
+   ```bash
+   python -m hr_mvp.cli search --keyword GURM
+   ```
+
+   ### 4) 시용(수습) 종료 예정자 확인
+   ```bash
+   python -m hr_mvp.cli probation --within 60
+   ```
+   - `--within` 값으로 며칠 이내를 볼지 지정합니다. 기본은 30일입니다.
+   - `--reference-date YYYY-MM-DD` 옵션을 주면 특정 기준일로 계산할 수 있습니다.
+
+4. 다른 CSV 파일을 사용하고 싶다면 `--path` 옵션에 파일 경로를 지정하면 됩니다.
+   ```bash
+   python -m hr_mvp.cli summary --path 다른파일.csv
+   ```
+
+## 데이터 구조
+
+`data/roster.csv` 파일에 아래와 같은 열이 포함되어 있습니다.
+
+| 열 이름 | 설명 |
+| --- | --- |
+| employee_id | 사번 |
+| payroll_id | 급여 사번 |
+| name | 이름 |
+| gender | 성별 |
+| birthdate | 생년월일 (YYYY-MM-DD) |
+| age_group | 연령대 |
+| team | 팀 |
+| part | 파트 |
+| title | 직책 |
+| start_date | 입사일 |
+| probation_end | 시용 종료일 |
+| resignation_date | 퇴사일 (없으면 공란) |
+| tenure_text | 근속기간(문자열) |
+| prior_experience_text | 입사 전 경력 (문자열) |
+| total_experience_text | 총 경력 (문자열) |
+| contract_type | 근로계약 형태 |
+| phone | 개인 연락처 |
+| email | 이메일 |
+| work_location | 근무지 |
+| job_type | 사무직/비사무직 구분 |
+| employment_status | 재직 구분 |
+| employment_status_detail | 재직 구분 상세 (현재 데이터에서는 공란) |
+| prior_experience_months | 입사 전 경력(개월) |
+| current_experience_months | 현 직장 경력(개월) |
+| total_experience_months | 총 경력(개월) |
+
+필요시 `data/roster.csv`를 엑셀에서 열어 그대로 수정한 뒤 저장하면 CLI에서도
+바로 반영됩니다.
+
+## 테스트
+
+자동화 검증이 필요하다면 `pytest`로 간단한 테스트를 실행할 수 있습니다.
+```bash
+pytest
+```
+
+테스트는 기본 CSV가 정상적으로 로드되는지, 팀 통계와 검색 기능이 제대로
+동작하는지 등을 확인합니다.

--- a/data/roster.csv
+++ b/data/roster.csv
@@ -1,0 +1,7 @@
+employee_id,payroll_id,name,gender,birthdate,age_group,team,part,title,start_date,probation_end,resignation_date,tenure_text,prior_experience_text,total_experience_text,contract_type,phone,email,work_location,job_type,employment_status,employment_status_detail,prior_experience_months,current_experience_months,total_experience_months
+20101001,1000,이종윤,남,1982-02-27,40대,임원,,대표이사,2010-09-10,2010-12-09,,15년 0개월,,15년 0개월,정규직,010-3170-6148,jy.lee@gbh.kr,서울본사,사무직,1. 재직,,0,180,180
+20161001,1001,이다영,여,1989-11-01,30대,GURM,,팀원,2016-08-22,2016-11-21,,9년 1개월,00년 00개월,9년 1개월,정규직,010-4128-5345,gbh202@gbh.kr,서울본사,사무직,1. 재직,,0,109,109
+20161002,1002,지영윤,여,1992-03-07,30대,OPERATION,CS,파트장,2016-09-27,2016-12-26,,8년 11개월,,8년 11개월,정규직,010-9095-7062,gbh102@gbh.kr,서울본사,사무직,1. 재직,,0,107,107
+20161003,1003,이호영,여,1986-02-12,30대,GURM,,팀장,2016-11-14,2017-02-13,,8년 10개월,04년 09개월,13년 7개월,정규직,010-4615-0266,gbh301@gbh.kr,서울본사,사무직,1. 재직,,57,106,163
+20171004,1004,고빛나,여,1987-01-27,30대,OFFLINE,,팀장,2017-07-01,2017-09-30,,8년 2개월,,8년 2개월,정규직,010-9489-1415,gbh303@gbh.kr,서울본사,비사무직,1. 재직,,0,98,98
+20191002,1008,조현채,여,1987-06-02,30대,APPAREL,,팀장,2019-06-17,2019-09-16,,6년 3개월,08년 09개월,15년 0개월,정규직,010-4268-4589,gbh505@gbh.kr,서울본사,비사무직,1. 재직,,105,75,180

--- a/hr_mvp/__init__.py
+++ b/hr_mvp/__init__.py
@@ -1,0 +1,6 @@
+"""HR MVP package.
+
+Provides simple utilities for reading and reporting on employee roster data.
+"""
+
+from .roster import EmployeeRecord, EmployeeRoster  # noqa: F401

--- a/hr_mvp/cli.py
+++ b/hr_mvp/cli.py
@@ -1,0 +1,231 @@
+"""Command line helper around :mod:`hr_mvp.roster`.
+
+Usage examples::
+
+    # 전체 요약 정보 출력
+    python -m hr_mvp.cli summary
+
+    # 특정 팀 이름으로 검색
+    python -m hr_mvp.cli search --keyword GURM
+
+    # 60일 이내에 시용(수습) 종료 예정자 확인
+    python -m hr_mvp.cli probation --within 60
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+from typing import Optional, Sequence
+
+from .roster import EmployeeRecord, EmployeeRoster, load_default_roster
+
+
+def _load_roster(path: Optional[Path]) -> EmployeeRoster:
+    if path is None:
+        return load_default_roster()
+    return EmployeeRoster.from_csv(path)
+
+
+def _describe_months(months: Optional[float]) -> str:
+    if months is None:
+        return "-"
+    rounded = round(months)
+    years = int(rounded // 12)
+    remaining_months = int(rounded % 12)
+    parts = []
+    if years:
+        parts.append(f"{years}년")
+    if remaining_months:
+        parts.append(f"{remaining_months}개월")
+    if not parts:
+        parts.append("0개월")
+    if rounded != months:
+        parts.append(f"(약 {months:.1f}개월)")
+    return " ".join(parts)
+
+
+def cmd_summary(roster: EmployeeRoster) -> None:
+    active_count = len(roster.active())
+    total_count = len(roster)
+    avg_tenure = roster.average_tenure_months()
+
+    print("================")
+    print("인사 현황 요약")
+    print("================")
+    print(f"전체 인원: {total_count}명")
+    print(f"재직 인원: {active_count}명")
+    print(f"평균 근속기간(재직자): {_describe_months(avg_tenure)}")
+    print()
+
+    print("[팀별 재직 인원]")
+    for team, count in roster.summary_by_team().items():
+        print(f"- {team}: {count}명")
+    print()
+
+    print("[재직구분별 인원]")
+    for status, count in roster.summary_by_status().items():
+        print(f"- {status}: {count}명")
+
+
+def cmd_list(roster: EmployeeRoster, active_only: bool = False) -> None:
+    employees = roster.active() if active_only else list(roster)
+    if not employees:
+        print("표시할 인원이 없습니다.")
+        return
+    print(roster.to_table(employees))
+
+
+def cmd_search(roster: EmployeeRoster, keyword: str) -> None:
+    results = roster.search(keyword)
+    if not results:
+        print(f"'{keyword}'에 해당하는 인원을 찾을 수 없습니다.")
+        return
+    print(f"총 {len(results)}명 발견")
+    print(roster.to_table(results))
+
+
+def cmd_probation(roster: EmployeeRoster, within_days: int, reference_date: Optional[date]) -> None:
+    results = roster.upcoming_probation_end(within_days=within_days, reference_date=reference_date)
+    if not results:
+        print("해당 기간 내 시용 종료 예정자가 없습니다.")
+        return
+    print("시용 종료 예정자 목록")
+    print("--------------------")
+    for employee in results:
+        remaining = employee.probation_days_remaining(reference_date)
+        end_date = employee.probation_end.strftime("%Y-%m-%d") if employee.probation_end else "-"
+        print(f"{employee.name} ({employee.team}) - 종료일: {end_date} / D-{remaining}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="인사 명부 분석 도구")
+    parser.add_argument(
+        "--path",
+        type=Path,
+        help="다른 CSV 파일을 사용하고 싶으면 경로를 지정하세요.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("summary", help="요약 통계 확인")
+
+    list_parser = subparsers.add_parser("list", help="직원 목록 출력")
+    list_parser.add_argument(
+        "--active-only",
+        action="store_true",
+        help="재직 중인 인원만 보여줍니다.",
+    )
+
+    search_parser = subparsers.add_parser("search", help="이름/팀/직책 검색")
+    search_parser.add_argument("--keyword", required=True, help="검색어(부분 일치)")
+
+    probation_parser = subparsers.add_parser("probation", help="시용 종료 예정자 확인")
+    probation_parser.add_argument(
+        "--within",
+        type=int,
+        default=30,
+        help="며칠 이내 종료 예정자를 볼지 지정합니다 (기본 30일).",
+    )
+    probation_parser.add_argument(
+        "--reference-date",
+        type=lambda value: date.fromisoformat(value),
+        help="기준일(YYYY-MM-DD). 지정하지 않으면 오늘 날짜.",
+    )
+
+    return parser
+
+
+def run_interactive_menu(roster: EmployeeRoster) -> None:
+    """간단한 텍스트 메뉴를 통해 주요 기능을 실행한다."""
+
+    def _pause() -> None:
+        input("\n계속하려면 Enter 키를 누르세요...")
+
+    while True:
+        print("==========================")
+        print("인사 명부 도우미 (MVP)")
+        print("==========================")
+        print("1. 전체 요약 보기")
+        print("2. 전체 직원 목록 보기")
+        print("3. 재직자만 목록 보기")
+        print("4. 이름/팀/직책 검색")
+        print("5. 시용 종료 예정자 확인")
+        print("Q. 종료")
+
+        choice = input("원하는 번호를 입력하세요: ").strip().lower()
+        print()
+
+        if choice in {"q", "quit", "exit"}:
+            print("프로그램을 종료합니다.")
+            return
+        if choice == "1":
+            cmd_summary(roster)
+            _pause()
+        elif choice == "2":
+            cmd_list(roster, active_only=False)
+            _pause()
+        elif choice == "3":
+            cmd_list(roster, active_only=True)
+            _pause()
+        elif choice == "4":
+            keyword = input("검색어를 입력하세요: ").strip()
+            if not keyword:
+                print("검색어를 입력하지 않았습니다.")
+            else:
+                print()
+                cmd_search(roster, keyword)
+            _pause()
+        elif choice == "5":
+            within_raw = input("며칠 이내 종료 예정자를 볼까요? (기본 30): ").strip()
+            if within_raw:
+                try:
+                    within_days = int(within_raw)
+                except ValueError:
+                    print("숫자로 입력해주세요.")
+                    _pause()
+                    continue
+            else:
+                within_days = 30
+            reference_raw = input("기준일이 있다면 YYYY-MM-DD 형식으로 입력하세요 (엔터시 오늘 기준): ").strip()
+            reference_date = None
+            if reference_raw:
+                try:
+                    reference_date = date.fromisoformat(reference_raw)
+                except ValueError:
+                    print("날짜 형식이 올바르지 않습니다.")
+                    _pause()
+                    continue
+            print()
+            cmd_probation(roster, within_days=within_days, reference_date=reference_date)
+            _pause()
+        else:
+            print("지원하지 않는 선택입니다. 다시 입력해주세요.")
+            _pause()
+        print()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    roster = _load_roster(args.path)
+
+    if args.command is None:
+        run_interactive_menu(roster)
+        return
+
+    if args.command == "summary":
+        cmd_summary(roster)
+    elif args.command == "list":
+        cmd_list(roster, active_only=args.active_only)
+    elif args.command == "search":
+        cmd_search(roster, args.keyword)
+    elif args.command == "probation":
+        cmd_probation(roster, args.within, args.reference_date)
+    else:
+        parser.error("알 수 없는 명령입니다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hr_mvp/roster.py
+++ b/hr_mvp/roster.py
@@ -1,0 +1,243 @@
+"""Utilities to work with the employee roster CSV file.
+
+This module intentionally keeps the logic straightforward so that a
+non-developer can follow how data is loaded and analysed.  The
+:class:`EmployeeRoster` class is the main entry point that provides handy
+helpers for listing staff, computing summaries and spotting upcoming
+probation deadlines.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+
+def _parse_date(value: str) -> Optional[date]:
+    value = value.strip()
+    if not value:
+        return None
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def _parse_int(value: str) -> Optional[int]:
+    value = value.strip()
+    if not value:
+        return None
+    return int(value)
+
+
+def _format_months(months: Optional[int]) -> str:
+    if months is None:
+        return "-"
+    years, remaining_months = divmod(months, 12)
+    if years and remaining_months:
+        return f"{years}년 {remaining_months}개월"
+    if years:
+        return f"{years}년"
+    return f"{remaining_months}개월"
+
+
+@dataclass
+class EmployeeRecord:
+    """Represents a single row from the roster CSV file."""
+
+    employee_id: str
+    payroll_id: str
+    name: str
+    gender: str
+    birthdate: Optional[date]
+    age_group: str
+    team: str
+    part: str
+    title: str
+    start_date: Optional[date]
+    probation_end: Optional[date]
+    resignation_date: Optional[date]
+    tenure_text: str
+    prior_experience_text: str
+    total_experience_text: str
+    contract_type: str
+    phone: str
+    email: str
+    work_location: str
+    job_type: str
+    employment_status: str
+    employment_status_detail: str
+    prior_experience_months: Optional[int]
+    current_experience_months: Optional[int]
+    total_experience_months: Optional[int]
+
+    @classmethod
+    def from_row(cls, row: Dict[str, str]) -> "EmployeeRecord":
+        return cls(
+            employee_id=row["employee_id"].strip(),
+            payroll_id=row["payroll_id"].strip(),
+            name=row["name"].strip(),
+            gender=row["gender"].strip(),
+            birthdate=_parse_date(row["birthdate"]),
+            age_group=row["age_group"].strip(),
+            team=row["team"].strip(),
+            part=row["part"].strip(),
+            title=row["title"].strip(),
+            start_date=_parse_date(row["start_date"]),
+            probation_end=_parse_date(row["probation_end"]),
+            resignation_date=_parse_date(row["resignation_date"]),
+            tenure_text=row["tenure_text"].strip(),
+            prior_experience_text=row["prior_experience_text"].strip(),
+            total_experience_text=row["total_experience_text"].strip(),
+            contract_type=row["contract_type"].strip(),
+            phone=row["phone"].strip(),
+            email=row["email"].strip(),
+            work_location=row["work_location"].strip(),
+            job_type=row["job_type"].strip(),
+            employment_status=row["employment_status"].strip(),
+            employment_status_detail=row["employment_status_detail"].strip(),
+            prior_experience_months=_parse_int(row["prior_experience_months"]),
+            current_experience_months=_parse_int(row["current_experience_months"]),
+            total_experience_months=_parse_int(row["total_experience_months"]),
+        )
+
+    @property
+    def is_active(self) -> bool:
+        if self.resignation_date is not None:
+            return False
+        return "재직" in self.employment_status
+
+    @property
+    def tenure_months(self) -> Optional[int]:
+        return self.current_experience_months
+
+    def tenure_display(self) -> str:
+        if self.tenure_months is not None:
+            return _format_months(self.tenure_months)
+        return self.tenure_text or "-"
+
+    def total_experience_display(self) -> str:
+        if self.total_experience_months is not None:
+            return _format_months(self.total_experience_months)
+        return self.total_experience_text or "-"
+
+    def matches(self, keyword: str) -> bool:
+        keyword_lower = keyword.lower()
+        return (
+            keyword_lower in self.name.lower()
+            or keyword_lower in self.team.lower()
+            or keyword_lower in self.part.lower()
+            or keyword_lower in self.title.lower()
+        )
+
+    def probation_days_remaining(self, reference_date: Optional[date] = None) -> Optional[int]:
+        if self.probation_end is None:
+            return None
+        reference_date = reference_date or date.today()
+        delta = self.probation_end - reference_date
+        return delta.days
+
+
+class EmployeeRoster:
+    """Collection of :class:`EmployeeRecord` objects with helper methods."""
+
+    def __init__(self, employees: Sequence[EmployeeRecord]):
+        self._employees: List[EmployeeRecord] = list(employees)
+
+    def __iter__(self) -> Iterable[EmployeeRecord]:
+        return iter(self._employees)
+
+    def __len__(self) -> int:
+        return len(self._employees)
+
+    @property
+    def employees(self) -> Sequence[EmployeeRecord]:
+        return tuple(self._employees)
+
+    @classmethod
+    def from_csv(cls, path: Path) -> "EmployeeRoster":
+        with path.open("r", encoding="utf-8", newline="") as fh:
+            reader = csv.DictReader(fh)
+            employees = [EmployeeRecord.from_row(row) for row in reader]
+        return cls(employees)
+
+    def active(self) -> List[EmployeeRecord]:
+        return [employee for employee in self._employees if employee.is_active]
+
+    def summary_by_team(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for employee in self.active():
+            key = employee.team or "(미지정)"
+            counts[key] = counts.get(key, 0) + 1
+        return dict(sorted(counts.items(), key=lambda item: item[0]))
+
+    def summary_by_status(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for employee in self._employees:
+            key = employee.employment_status or "(미지정)"
+            counts[key] = counts.get(key, 0) + 1
+        return dict(sorted(counts.items(), key=lambda item: item[0]))
+
+    def average_tenure_months(self, active_only: bool = True) -> Optional[float]:
+        population = self.active() if active_only else list(self._employees)
+        tenures = [emp.tenure_months for emp in population if emp.tenure_months is not None]
+        if not tenures:
+            return None
+        return sum(tenures) / len(tenures)
+
+    def search(self, keyword: str) -> List[EmployeeRecord]:
+        keyword = keyword.strip()
+        if not keyword:
+            return []
+        return [employee for employee in self._employees if employee.matches(keyword)]
+
+    def upcoming_probation_end(
+        self, within_days: int = 30, reference_date: Optional[date] = None
+    ) -> List[EmployeeRecord]:
+        reference_date = reference_date or date.today()
+        window_end = reference_date + timedelta(days=within_days)
+        results: List[EmployeeRecord] = []
+        for employee in self.active():
+            if employee.probation_end is None:
+                continue
+            if reference_date <= employee.probation_end <= window_end:
+                results.append(employee)
+        results.sort(key=lambda emp: emp.probation_end or date.max)
+        return results
+
+    def to_table(self, employees: Sequence[EmployeeRecord]) -> str:
+        headers = ["사번", "이름", "팀", "직책", "고용형태", "근속기간", "총경력"]
+        rows = []
+        for employee in employees:
+            rows.append(
+                [
+                    employee.employee_id,
+                    employee.name,
+                    employee.team or "-",
+                    employee.title or "-",
+                    employee.contract_type or "-",
+                    employee.tenure_display(),
+                    employee.total_experience_display(),
+                ]
+            )
+
+        col_widths = [len(header) for header in headers]
+        for row in rows:
+            for idx, cell in enumerate(row):
+                col_widths[idx] = max(col_widths[idx], len(str(cell)))
+
+        def format_row(row_values: Sequence[str]) -> str:
+            return " | ".join(
+                str(value).ljust(col_widths[idx]) for idx, value in enumerate(row_values)
+            )
+
+        lines = [format_row(headers), "-+-".join("-" * width for width in col_widths)]
+        lines.extend(format_row(row) for row in rows)
+        return "\n".join(lines)
+
+
+def load_default_roster() -> EmployeeRoster:
+    """Load the roster.csv file bundled with the project."""
+
+    default_path = Path(__file__).resolve().parent.parent / "data" / "roster.csv"
+    return EmployeeRoster.from_csv(default_path)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,0 +1,31 @@
+from datetime import date
+from pathlib import Path
+
+from hr_mvp.roster import EmployeeRoster, load_default_roster
+
+
+def test_load_default_roster(tmp_path):
+    roster = load_default_roster()
+    assert len(roster) == 6
+    assert roster.employees[0].name == "이종윤"
+
+
+def test_summary_by_team():
+    roster = load_default_roster()
+    summary = roster.summary_by_team()
+    assert summary["GURM"] == 2
+    assert summary["임원"] == 1
+
+
+def test_search_by_name():
+    roster = load_default_roster()
+    results = roster.search("이호")
+    assert len(results) == 1
+    assert results[0].team == "GURM"
+
+
+def test_probation_window():
+    roster = load_default_roster()
+    reference = date(2016, 8, 1)
+    results = roster.upcoming_probation_end(within_days=120, reference_date=reference)
+    assert {employee.name for employee in results} == {"이다영"}


### PR DESCRIPTION
## Summary
- add an interactive text menu so running the CLI without arguments guides non-developers through the main workflows
- keep the direct subcommands for power users while updating the README with the new default instructions

## Testing
- pytest
- python -m hr_mvp.cli summary

------
https://chatgpt.com/codex/tasks/task_e_68d38ec3d084832fbce1e35ef56007f0